### PR TITLE
Add water surface elevation BC on ADCIRC side

### DIFF
--- a/adcirc_nn/coupler/adcirc_nn_class.py
+++ b/adcirc_nn/coupler/adcirc_nn_class.py
@@ -57,7 +57,7 @@ class AdcircNN():
         self.adcircedgestringid=self.pu.unset_int
         self.adcircedgestringnnodes=self.pu.unset_int
         self.adcircedgestringlen=0.0
-        self.adcircfort20pathname=''
+        self.adcircfort19pathname=''
         self.adcirc_hprev=0.0   # Avg depth
         self.adcirc_hprev_len=0.0   # count
 
@@ -108,7 +108,7 @@ class AdcircNN():
         self.adcirctnext=self.adcirctprev
         self.adcirctfinal=(self.pg.statim + self.pg.rnday)*86400.0
         self.adcircntsteps=0+self.pmain.itime_end #Needed 0+ to prevent the two from being the same object :-/ Careful!!!!
-        self.adcircfort20pathname=''.join(np.append(np.char.strip(self.ps.inputdir),'/fort.20.new'))
+        self.adcircfort19pathname=''.join(np.append(np.char.strip(self.ps.inputdir),'/fort.19.new'))
         self.adcircedgestringid=int(argv[argc.value-1])-1
         self.adcircedgestringnnodes=self.pb.nvell[self.adcircedgestringid]
         self.adcircedgestringnodes=self.pb.nbvv[1:self.adcircedgestringnnodes]

--- a/adcirc_nn/coupler/adcirc_set_bc_func.py
+++ b/adcirc_nn/coupler/adcirc_set_bc_func.py
@@ -13,43 +13,41 @@ def adcirc_set_bc_from_nn_hydrograph(ags): # ags is an Adcirc_NN_class object.
 
     ########## Set ADCIRC Boundary Conditions ###########
     # Note: ags.adcircseries already points to the head of series in ADCIRC that needs to be modified.
-    nbvStartIndex=sum(ags.pb.nvell[:ags.adcircedgestringid])
+    db_el_StartIndex=sum(ags.pb.nvdll[:ags.adcircedgestringid])
     if ags.pu.debug == ags.pu.on and DEBUG_LOCAL != 0 and ags.myid==0:
-        print(f"\nOriginal: Flux time increment FTIMINC = {ags.pg.ftiminc}"
-                f"\nOriginal: Flux times:\nQTIME1 = {ags.pg.qtime1}"
-                f"\nQTIME2 = {ags.pg.qtime2}"
-                f"\nOriginal: Flux values:\nQNIN1  = {ags.pg.qnin1[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes]}"
-                f"\nQNIN2  = {ags.pg.qnin2[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes]}")
+        print(f"\nOriginal: Flux time increment ETIMINC = {ags.pg.etiminc}"
+                f"\nOriginal: Flux times:\nETIME1 = {ags.pg.etime1}"
+                f"\nETIME2 = {ags.pg.etime2}"
+                f"\nOriginal: Flux values:\nESBIN1  = {ags.pg.esbin1[db_el_StartIndex : db_el_StartIndex+ags.adcircedgestringnnodes]}"
+                f"\nESBIN2  = {ags.pg.esbin2[db_el_StartIndex : db_el_StartIndex+ags.adcircedgestringnnodes]}")
 
     if ags.pu.messg == ags.pu.on:
         if ags.myid != 0:
-            messgvout  = -1.0E+200
+            messgelev  = -1.0E+200
         else:
-            messgvout  = ags.nn.vout
+            messgelev  = ags.nn.elev
         if (ags.pu.debug ==ags.pu.on or ags.nn._DEBUG == ags.pu.on) or DEBUG_LOCAL != 0:
-            print(f'PE[{ags.myid}] Before messg: vout = {ags.nn.vout}')
-        ags.nn.vout  = ags.pmsg.pymessg_dbl_max(messgvout, ags.adcirc_comm_comp)
+            print(f'PE[{ags.myid}] Before messg: elev = {ags.nn.elev}')
+        ags.nn.elev  = ags.pmsg.pymessg_dbl_max(messgelev, ags.adcirc_comm_comp)
         if (ags.pu.debug ==ags.pu.on or ags.nn._DEBUG == ags.pu.on) or DEBUG_LOCAL != 0:
-            print(f'PE[{ags.myid}] After messg : vout = {ags.nn.vout}')
+            print(f'PE[{ags.myid}] After messg : elev = {ags.nn.elev}')
 
     ######################################################
-    # Close the original fort.20
-    errorio = ags.pu.pycloseopenedfileforread(20)
+    # Close the original fort.19
+    errorio = ags.pu.pycloseopenedfileforread(19)
     assert(errorio==0)
 
     if (ags.nn.runflag != ags.pu.off):
 
         # Inflow volume in the current nn time step:
-        # V=(t2-t1)(q1+q2)/2; So to conserve mass entering in ADCIRC in interval t2-t1, q2 = 2*V/(t2-t1) - q1  in cu.m/s
-        # Therefore, in (cu.m/s)/m, ADCIRC series value be val2 = 2*V/(t2-t1)/edgestringleng - val1; since val_i=q_i/edgestringlen
-        DV = (ags.nn.vout-ags.nn.voutprev)
-        if ags.couplingtype == 'AdgdA':
+        DH = (ags.nn.elev-ags.nn.elevprev)
+        if ags.couplingtype == 'AdndA':
             DT = 0.0
             ags.adcirctprev=ags.pu.pyfindelapsedtime(ags.pmain.itime_end) #Last time at which ADCIRC was paused & solution known
             while (ags.adcirctprev + DT < ags.nn.timer*ags.nn.timefact+ags.effectivenndt-TIME_TOL):
                 DT += ags.adcircdt
-        else: # For gda and gdadg:
-            DT = (ags.nn.timer-ags.nn.voutprev_t)*ags.nn.timefact + 1.0E-20
+        else: # For ndA and ndAdg:
+            DT = (ags.nn.timer-ags.nn.elevprev_t)*ags.nn.timefact + 1.0E-20
 
         if (ags.pu.debug ==ags.pu.on or ags.nn._DEBUG == ags.pu.on) and DEBUG_LOCAL != 0 and ags.myid == 0:
             # This is valid only for PE 0 which is running NN. Not on other PEs!
@@ -57,93 +55,79 @@ def adcirc_set_bc_from_nn_hydrograph(ags): # ags is an Adcirc_NN_class object.
             #outlet_depth = ags.nn.chan_depth[ags.nn.nx[ags.nn.nlinks]][ags.nn.nlinks]
             #print(f"outlet area       = {outlet_area} m2")
             #print(f"outlet chan_depth = {outlet_depth} m")
-            print(f"qout              = {ags.nn.qout} m3/s")
-            print(f"voutprev          = {ags.nn.voutprev} m3")
-            print(f"vout              = {ags.nn.vout} m3")
-            print(f"DV                = {DV} m3")
+            print(f"elevprev          = {ags.nn.elevprev} m")
+            print(f"elev              = {ags.nn.elev} m")
+            print(f"DH                = {DH} m")
             print(f"DT                = {DT} s")
-            #print(f"NN qout/area   = {ags.nn.qout / outlet_area} m/s")
-            #print(f"Avg. NN speed  ~ {DV / DT / outlet_area} m/s")
-            print(f"Avg. ADCIRC speed ~ {DV / DT} (m3/s) / ADCIRC area (needs more work!)")
-
-        if DV < 0.0:
-            print("Warning: Outflow from ADCIRC model forced by NN! This can"
-                  " cause instabilities in the model!")
 
         # Move current to previous: Current is at [2], previous is at [1]
         # Shift values backward
-        ags.pg.qtime1 = ags.pg.qtime2
-        for i in range(len(ags.pg.qnin1)):
-            ags.pg.qnin1[i] = ags.pg.qnin2[i]
+        ags.pg.etime1 = ags.pg.etime2
+        for i in range(len(ags.pg.esbin1)):
+            ags.pg.esbin1[i] = ags.pg.esbin2[i]
 
         # Set ADCIRC series value for nn time t2
-        ags.pg.qtime2 = ags.nn.timer*ags.nn.timefact # This is NN time set in ADCIRC series.
-        if ags.couplingtype == 'AdgdA':
-            ags.pg.qtime2 = ags.adcirctprev+DT #ags.adcircdt # If 2-way AdgdA, then time series has to be shifted ahead since ADCIRC goes first.
+        ags.pg.etime2 = ags.nn.timer*ags.nn.timefact # This is NN time set in ADCIRC series.
+        if ags.couplingtype == 'AdndA':
+            ags.pg.etime2 = ags.adcirctprev+DT #ags.adcircdt # If 2-way AdndA, then time series has to be shifted ahead since ADCIRC goes first.
 
         # ADCIRC Series value
         #DT_calculated = ags.adcircseries[0].entry[SERIESLENGTH-2].time - ags.adcircseries[0].entry[SERIESLENGTH-3].time
         #print"DT_calculated     =", DT_calculated, "s"
         #DT_calculated affects how the mass is distributed. If we want to dump all the mass from NN into ADCIRC's next time step
         #no matter how large it may be, we should use DT_calculated. For now, I'm skipping DT_calculated.
-        oldseriesvalue = ags.pg.qnin2[nbvStartIndex]
-        #seriesvalue = (2*DV/DT/ags.adcircedgestringlen * ags.nn.hydrofact - oldseriesvalue)
-        seriesvalue =  ags.nn.qout/ags.adcircedgestringlen
-        ags.pg.qnin2[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes] = seriesvalue
-        with open(ags.adcircfort20pathname, 'w') as fort20file:
-            #print "QNIN values start at", nbvStartIndex
-            for i in range(ags.pb.nvel):
-                if ags.pb.lbcodei[i] in [2, 12, 22]:
-                    [fort20file.write('{0:10f}\n'.format(ags.pg.qnin2[i]))]
-                if ags.pb.lbcodei[i] == 32:
-                    [fort20file.write('{0:10f}  {1:10f}\n'.format(ags.pg.qnin2[i],ags.pg.enin2[i]))]
+        oldseriesvalue = ags.pg.esbin2[db_el_StartIndex]
+        #seriesvalue = (2*DH/DT/ags.adcircedgestringlen * ags.nn.hydrofact - oldseriesvalue)
+        seriesvalue =  ags.nn.elev
+        ags.pg.esbin2[db_el_StartIndex : db_el_StartIndex+ags.adcircedgestringnnodes] = seriesvalue
+        with open(ags.adcircfort19pathname, 'w') as fort19file:
+            #print "ESBIN values start at", db_el_StartIndex
+            for i in range(ags.pb.neta):
+                [fort19file.write('{0:10f}\n'.format(ags.pg.esbin2[i]))]
             # Now set the last value same as the current value, but not the time!
-            # TO IMPLEMENT THIS PART, JUST WRITE THE SERIES TWICE IN fort.22 replacement!
+            # TO IMPLEMENT THIS PART, JUST WRITE THE SERIES TWICE IN fort.19 replacement!
             #ags.adcircseries[0].entry[SERIESLENGTH-1].time     = ags.adcircseries[0].entry[SERIESLENGTH-2].time + TIME_TOL
             #ags.adcircseries[0].entry[SERIESLENGTH-1].value[0] = ags.adcircseries[0].entry[SERIESLENGTH-2].value[0]
-            for i in range(ags.pb.nvel):
-                if ags.pb.lbcodei[i] in [2, 12, 22]:
-                    [fort20file.write('{0:10f}\n'.format(ags.pg.qnin2[i]))]
-                if ags.pb.lbcodei[i] == 32:
-                    [fort20file.write('{0:10f}  {1:10f}\n'.format(ags.pg.qnin2[i],ags.pg.enin2[i]))]
+            for i in range(ags.pb.neta):
+                [fort19file.write('{0:10f}\n'.format(ags.pg.esbin2[i]))]
 
         # Calculate slope
         ags.adcircseriesslope = \
                 (seriesvalue - oldseriesvalue) / \
-                (ags.pg.qtime2 - ags.pg.qtime1)#+1.0E-14)
+                (ags.pg.etime2 - ags.pg.etime1)#+1.0E-14)
 
         # Calculate 'area', i.e., volume/unit width that has flown in at this time step.
         ags.adcircseriesarea  = 0.5 * \
                 (seriesvalue + oldseriesvalue) * \
-                (ags.pg.qtime2 - ags.pg.qtime1)
+                (ags.pg.etime2 - ags.pg.etime1)
 
         #Store volume for the next time step.
-        ags.nn.voutprev   = ags.nn.vout
-        ags.nn.voutprev_t = ags.nn.timer
+        ags.nn.elevprev   = ags.nn.elev
+        ags.nn.elevprev_t = ags.nn.timer
 
     else:
         # Shift values backward
-        ags.pg.qtime1 = ags.pg.qtime2
-        for i in range(ags.pb.nvel*2):
-            ags.pg.qnin1[i] = ags.pg.qnin2[i]
-        # Replace the fort.20 file.
-        with open(ags.adcircfort20pathname, 'w') as fort20file:
-            [fort20file.write('0.0\n') for i in range(ags.adcircedgestringnnodes*SERIESLENGTH)]
+        ags.pg.etime1 = ags.pg.etime2
+        for i in range(ags.pb.neta*2):
+            ags.pg.esbin1[i] = ags.pg.esbin2[i]
+        # Replace the fort.19 file.
+        with open(ags.adcircfort19pathname, 'w') as fort19file:
+            [fort19file.write('0.0\n') for i in range(ags.adcircedgestringnnodes*SERIESLENGTH)]
         # Reset the flux time increment
         # Gajanan gkc warning: Note that this will cause a problem if there are multiple non-zero-flux boundaries!!!
-        ags.pg.ftiminc = abs(ags.adcirctfinal)*10.0
+        ags.pg.etiminc = abs(ags.adcirctfinal)*10.0
 
     ######################################################
-    # Reopen the fort.20 replacement file
-    errorio = ags.pg.pyopenfileforread(20,ags.adcircfort20pathname)
+    # Reopen the fort.19 replacement file
+    errorio = ags.pg.pyopenfileforread(19,ags.adcircfort19pathname)
     assert(errorio==0)
 
     if ags.pu.debug == ags.pu.on and DEBUG_LOCAL != 0:
-        print(f"Replaced: Flux time increment FTIMINC = {ags.pg.ftiminc}"
-                f"\nReplaced: Flux times:\nQTIME1 = {ags.pg.qtime1}"
-                f"\nQTIME2 = {ags.pg.qtime2} "
-                f"\nReplaced: Flux values:\nQNIN1  = {ags.pg.qnin1[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes]}"
-                f"\nQNIN2  = {ags.pg.qnin2[nbvStartIndex : nbvStartIndex+ags.adcircedgestringnnodes]}")
+        print(f"Replaced: Flux time increment ETIMINC = {ags.pg.etiminc}"
+                f"\nReplaced: Flux times:\nETIME1 = {ags.pg.etime1}"
+                f"\nETIME2 = {ags.pg.etime2} "
+                f"\nReplaced: Flux values:\nESBIN1  = {ags.pg.esbin1[db_el_StartIndex : db_el_StartIndex+ags.adcircedgestringnnodes]}"
+                f"\nESBIN2  = {ags.pg.esbin2[db_el_StartIndex : db_el_StartIndex+ags.adcircedgestringnnodes]}")
         print(f'Area   contained  = {ags.adcircseriesarea}')
         print(f'Volume contained  = {ags.adcircseriesarea*ags.adcircedgestringlen}')
 

--- a/adcirc_nn/coupler/lstmnn.py
+++ b/adcirc_nn/coupler/lstmnn.py
@@ -29,15 +29,14 @@ class LongShortTermMemoryNN_class():
 
         self.tprev = 0.0 # Double in seconds  # To be set to timer
         self.tfinal = 0.0 # Double in seconds # To be set to niter
-        self.voutprev=0.0
-        self.voutprev_t=0.0
+        self.elevprev=0.0
+        self.elevprev_t=0.0
 
         self.timefact=NN_TIME_FACTOR # Minutes to seconds conversion, since niter is in mins.
 
         #self.dummytimes = 0.0
         #self.dummyvalues = 0.0
-        self.vout = 0.0
-        self.qout = 0.0
+        self.elev = 0.0
 
         self.runflag = 1 # Only for use in coupling with ADCIRC.
 
@@ -49,8 +48,7 @@ class LongShortTermMemoryNN_class():
         self.dt = 60.0
         self.timer = 0
         self.niter = 21600
-        self.qbcfunc = lambda t : 1.0e1*(1-np.cos(2.0*np.pi * t / self.tfinal))
-        self.vbcfunc = lambda t : 1.0e1*(t-np.sin(2.0*np.pi * t / self.tfinal)*self.tfinal/4.0/np.pi)
+        self.elbcfunc = lambda t : 5.0e0*(1-np.cos(2.0*np.pi * t / self.tfinal))
         #self.dummytimes = np.arange(0.0, self.dt*5, self.tfinal)
         #self.dummyvalues = 1.0e3*(1-np.cos(4.0*np.pi/self.dummytimes))
 
@@ -64,8 +62,7 @@ class LongShortTermMemoryNN_class():
 
         # Run the NN model. For now, just set the dummy value for next "t"
         while (self.timer < self.niter):
-            self.vout = self.vbcfunc(self.timer + self.dt)
-            self.qout = self.qbcfunc(self.timer + self.dt)
+            self.elev = self.elbcfunc(self.timer + self.dt)
             # Increment model time
             self.timer += self.dt
 


### PR DESCRIPTION
This is related to PR #1.

To do:
If there are multiple open (elevation) boundaries with BC series specified,
then the current way of overriding fort.19 will cause problems and might
fail.